### PR TITLE
Document Android instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The real power, though, is in its URL schemes. The clear-cut commands `obsidian:
 
 - Install an app that creates a homescreen shortcut that open a URL, e.g. [this](https://play.google.com/store/apps/details?id=com.deltacdev.websiteshortcut).
 - Create a new shortcut with `obsidian://log`
-- Stiking the shortcut opens your daily note, so start logging!
+- Striking the shortcut opens your daily note, so start logging!
 
 ### Manually installing the plugin
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ The real power, though, is in its URL schemes. The clear-cut commands `obsidian:
 - Run the `obsidian://log` command to open Obsidian and log a new thought in your daily note at an appended line and start writing immediately.
   - On iOS, this is easy to set up via Shortcuts. Install [this shortcut](https://www.icloud.com/shortcuts/1efa6b9ee42242bd906884d3d8a52b92), add it to your homescreen, then tap the button! 
 - Run the `obsidian://timber` command to create a new draft in a designated inbox folder and start writing immediately.
-  -  On iOS, this is easy to set up via Shortcuts. Install [this shortcut](https://www.icloud.com/shortcuts/6594b965deab401e814aeeeb593b551d), add it to your homescreen, then tap the button! 
+  -  On iOS, this is easy to set up via Shortcuts. Install [this shortcut](https://www.icloud.com/shortcuts/6594b965deab401e814aeeeb593b551d), add it to your homescreen, then tap the button!
+
+#### Setting up on Android
+
+- Install an app that creates a homescreen shortcut that open a URL, e.g. [this](https://play.google.com/store/apps/details?id=com.deltacdev.websiteshortcut).
+- Create a new shortcut with `obsidian://log`
+- Stiking the shortcut opens your daily note, so start logging!
 
 ### Manually installing the plugin
 


### PR DESCRIPTION
- [x] Included logging metaphor

Add instructions for how to set-up home screen shortcut on Android.
Include link to the url-to-shortcut app I use, because it's kind of a niche utility to have installed.

## Why creating PR

I was looking for homescreen "open daily note" button and found [your app suggested on reddit](https://www.reddit.com/r/ObsidianMD/comments/wgto2f/comment/ijjrzlv/?context=3) with some confusion if only iOS was supported.

I've been using this setup for a week and it works great!